### PR TITLE
chore: workaround to make the language server find root config.

### DIFF
--- a/terramate.tm.hcl
+++ b/terramate.tm.hcl
@@ -1,4 +1,6 @@
 terramate {
+  required_version                   = ">= 0.8.4"
+  required_version_allow_prereleases = true
   config {
 
     # Configure the namespace of your Terramate Cloud organization


### PR DESCRIPTION
The VSCode extension is showing linter warnings for the script blocks when defined outside root directory. This happens because the `terramate-ls` still **do not** use `git` to find the repository root but rely in the discovery of the `terramate` block containing a `required_version` attribute...

Sorry about that.