### PR TITLE
Add mandatory description

### DIFF
--- a/stacks/opentofu/workflows.tm.hcl
+++ b/stacks/opentofu/workflows.tm.hcl
@@ -85,6 +85,8 @@ script "tofu" "render" {
 
 
 script "safe-guard" {
+  description = "Safe-guard the workflow"
+
   job {
     command = ["true"]
   }

--- a/stacks/terraform/workflows.tm.hcl
+++ b/stacks/terraform/workflows.tm.hcl
@@ -84,6 +84,8 @@ script "terraform" "render" {
 }
 
 script "safe-guard" {
+  description = "Safe-guard the workflow"
+
   job {
     command = ["true"]
   }


### PR DESCRIPTION
A description is enforced and add a error message, this solves it. 

I realized that this is irrelevant, since I first had terramate 0.5.0 installed from https://aur.archlinux.org/packages/terramate 